### PR TITLE
test: use command strings to test when the `CMD_XXX` ones are changed

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,9 +10,6 @@ from copr.v3.exceptions import CoprNoResultException
 from llvm_snapshot_builder.mixins.client_mixin import CoprClientMixin
 from llvm_snapshot_builder.cli import main
 from llvm_snapshot_builder import __version__
-from llvm_snapshot_builder.cli import CMD_BUILD_PACKAGES, CMD_CANCEL_BUILDS, \
-    CMD_CREATE_PACKAGES, CMD_CREATE_PROJECT, CMD_DELETE_PROJECT, CMD_PROJECT_EXISTS, \
-    CMD_BUILD_ALL_PACKAGES
 
 # TODO(kwk): Implement recipe tests as I did in Golang for fabric8-wit
 
@@ -41,9 +38,9 @@ class TestCLI(unittest.TestCase):
 
     def test_project_exists(self):
         """ Test project-exists command. """
-        self.assertTrue(main([CMD_PROJECT_EXISTS, "--proj", "@copr/copr"]))
+        self.assertTrue(main(['project-exists', "--proj", "@copr/copr"]))
         self.assertFalse(
-            main([CMD_PROJECT_EXISTS, "--proj", f"@copr/{uuid.uuid4()}"]))
+            main(['project-exists', "--proj", f"@copr/{uuid.uuid4()}"]))
 
     def test_version(self):
         """ Test version flag command. """
@@ -58,52 +55,52 @@ class TestCLI(unittest.TestCase):
     def test_create_project_ok(self):
         """ Test create-project command. """
         ref = f"{self.owner}/{uuid.uuid4()}"
-        self.assertFalse(main([CMD_PROJECT_EXISTS, "--proj", ref]))
+        self.assertFalse(main(['project-exists', "--proj", ref]))
 
         with self.get_text_file(text="foobar description") as description:
             with self.get_text_file(text="foobar instructions") as instructions:
                 self.assertTrue(
-                    main([CMD_CREATE_PROJECT,
+                    main(['create-project',
                           "--proj", ref,
                           "--description-file", description,
                           "--instructions-file", instructions,
                           "--delete-after-days", "0"]))
 
-        self.assertTrue(main([CMD_PROJECT_EXISTS, "--proj", ref]))
-        self.assertTrue(main([CMD_DELETE_PROJECT, "--proj", ref]))
-        self.assertFalse(main([CMD_PROJECT_EXISTS, "--proj", ref]))
+        self.assertTrue(main(['project-exists', "--proj", ref]))
+        self.assertTrue(main(['delete-project', "--proj", ref]))
+        self.assertFalse(main(['project-exists', "--proj", ref]))
 
     def test_create_project_with_update(self):
         """ Test create-project command. """
         ref = f"{self.owner}/{uuid.uuid4()}"
-        self.assertFalse(main([CMD_PROJECT_EXISTS, "--proj", ref]))
+        self.assertFalse(main(['project-exists', "--proj", ref]))
 
         with self.get_text_file(text="foobar description") as description:
             with self.get_text_file(text="foobar instructions") as instructions:
                 self.assertTrue(
-                    main([CMD_CREATE_PROJECT,
+                    main(['create-project',
                           "--proj", ref,
                           "--description-file", description,
                           "--instructions-file", instructions,
                           "--delete-after-days", "0"]))
 
-        self.assertTrue(main([CMD_PROJECT_EXISTS, "--proj", ref]))
-        self.assertTrue(main([CMD_DELETE_PROJECT, "--proj", ref]))
-        self.assertFalse(main([CMD_PROJECT_EXISTS, "--proj", ref]))
+        self.assertTrue(main(['project-exists', "--proj", ref]))
+        self.assertTrue(main(['delete-project', "--proj", ref]))
+        self.assertFalse(main(['project-exists', "--proj", ref]))
 
     def test_create_and_build_packages(self):
         """ Tests create-packages and build-packages commands. """
         ref = f"{self.owner}/{uuid.uuid4()}"
-        self.assertFalse(main([CMD_PROJECT_EXISTS, "--proj", ref]))
-        self.assertTrue(main([CMD_CREATE_PROJECT, "--proj", ref]))
-        self.assertTrue(main([CMD_PROJECT_EXISTS, "--proj", ref]))
+        self.assertFalse(main(['project-exists', "--proj", ref]))
+        self.assertTrue(main(['create-project', "--proj", ref]))
+        self.assertTrue(main(['project-exists', "--proj", ref]))
         self.assertTrue(
-            main([CMD_CREATE_PACKAGES, "--proj", ref, "--packagenames", "llvm"]))
+            main(['create-packages', "--proj", ref, "--packagenames", "llvm"]))
         with self.assertLogs(level='WARNING') as ctxmgr:
             # this should write a warning to the log because the package already
             # exists but is not updated due to the absence of --update.
             self.assertTrue(
-                main([CMD_CREATE_PACKAGES, "--proj", ref, "--packagenames", "llvm"]))
+                main(['create-packages', "--proj", ref, "--packagenames", "llvm"]))
         self.assertEqual(
             ctxmgr.output,
             ['WARNING:root:package already exists and is not updated: llvm'])
@@ -111,23 +108,23 @@ class TestCLI(unittest.TestCase):
         #            See https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertNoLogs
         # with self.assertNoLogs(level='WARNING'):
         #     self.assertTrue(
-        # main([CMD_CREATE_PACKAGES, "--proj", ref, "--packagenames", "llvm",
+        # main(['create-packages', "--proj", ref, "--packagenames", "llvm",
         # "--update"]))
         self.assertTrue(
-            main(["--debug", CMD_BUILD_PACKAGES, "--proj", ref, "--packagenames", "llvm"]))
-        self.assertTrue(main([CMD_CANCEL_BUILDS, "--proj", ref]))
-        self.assertTrue(main([CMD_DELETE_PROJECT, "--proj", ref]))
-        self.assertFalse(main([CMD_PROJECT_EXISTS, "--proj", ref]))
+            main(["--debug", 'build-packages', "--proj", ref, "--packagenames", "llvm"]))
+        self.assertTrue(main(['cancel-builds', "--proj", ref]))
+        self.assertTrue(main(['delete-project', "--proj", ref]))
+        self.assertFalse(main(['project-exists', "--proj", ref]))
 
     def test_create_and_build_all_packages(self):
         """ Tests create-packages and build-all-packages commands. """
         ref = f"{self.owner}/{uuid.uuid4()}"
-        self.assertTrue(main([CMD_CREATE_PROJECT, "--proj", ref]))
-        self.assertTrue(main([CMD_CREATE_PACKAGES, "--proj", ref]))
+        self.assertTrue(main(['create-project', "--proj", ref]))
+        self.assertTrue(main(['create-packages', "--proj", ref]))
         self.assertTrue(
-            main(["--debug", CMD_BUILD_ALL_PACKAGES, "--proj", ref]))
-        self.assertTrue(main([CMD_CANCEL_BUILDS, "--proj", ref]))
-        self.assertTrue(main([CMD_DELETE_PROJECT, "--proj", ref]))
+            main(["--debug", 'build-all-packages', "--proj", ref]))
+        self.assertTrue(main(['cancel-builds', "--proj", ref]))
+        self.assertTrue(main(['delete-project', "--proj", ref]))
 
     def test_create_project_with_manual_chroot(self):
         """
@@ -135,32 +132,32 @@ class TestCLI(unittest.TestCase):
         chroots and one that was not set up onecommands.
         """
         ref = f"{self.owner}/{uuid.uuid4()}"
-        self.assertTrue(main([CMD_CREATE_PROJECT,
+        self.assertTrue(main(['create-project',
                               "--proj",
                               ref,
                               "--chroots",
                               "fedora-rawhide-aarch64",
                               "fedora-rawhide-s390x"]))
-        self.assertTrue(main([CMD_CREATE_PACKAGES, "--proj", ref]))
+        self.assertTrue(main(['create-packages', "--proj", ref]))
         self.assertTrue(main(["--debug",
-                              CMD_BUILD_ALL_PACKAGES,
+                              'build-all-packages',
                               "--proj",
                               ref,
                               "--chroots",
                               "fedora-rawhide-aarch64",
                               "fedora-rawhide-s390x"]))
-        self.assertTrue(main([CMD_CANCEL_BUILDS, "--proj", ref]))
+        self.assertTrue(main(['cancel-builds', "--proj", ref]))
         with self.assertRaises(CoprNoResultException) as ex:
             self.assertTrue(main(["--debug",
-                                  CMD_BUILD_ALL_PACKAGES,
+                                  'build-all-packages',
                                   "--proj",
                                   ref,
                                   "--chroots",
                                   "fedora-rawhide-ppc64le"]))
         self.assertEqual(str(ex.exception),
                          "Chroot name fedora-rawhide-ppc64le does not exist.")
-        self.assertTrue(main([CMD_CANCEL_BUILDS, "--proj", ref]))
-        self.assertTrue(main([CMD_DELETE_PROJECT, "--proj", ref]))
+        self.assertTrue(main(['cancel-builds', "--proj", ref]))
+        self.assertTrue(main(['delete-project', "--proj", ref]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We don't want to cause a regression in case someone modifies the `CMD_XXXX` command constants.